### PR TITLE
Add Docker support for running Spotish bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+__pycache__
+*.py[cod]
+*.log
+.env
+example.env
+Songs/
+images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies required by python-vlc and audio playback
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        vlc \
+        libvlc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies separately to leverage Docker layer caching
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+RUN mkdir -p Songs
+
+# Expose ports used by the bot services
+EXPOSE 5000 7000
+
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -230,6 +230,25 @@ Python 3.11.8
     python run.py
   ```
 
+### Docker
+
+You can also run Spotish inside a Docker container.
+
+1. Copy `example.env` to `.env` and update it with your configuration (see steps above).
+2. Build the image:
+   ```bash
+   docker build -t spotish .
+   ```
+3. Run the container, mounting a volume so downloaded songs persist and providing your environment variables:
+   ```bash
+   docker run --env-file .env \
+     -v "$(pwd)/Songs:/app/Songs" \
+     -p 5000:5000 -p 7000:7000 \
+     spotish
+   ```
+
+The Docker image installs VLC and FFmpeg so playback works out of the box. Mounting the `Songs` directory ensures tracks downloaded by the bot are available across container restarts.
+
 
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs VLC/FFmpeg dependencies and runs the bot entrypoint
- ignore local assets and secrets from the build context with a new .dockerignore
- document container build and run instructions in the README

## Testing
- docker build -t spotish-test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0133c5fe883318a968bbbfc91ad98